### PR TITLE
detect cluster ingress

### DIFF
--- a/chart/hello/templates/_helpers.tpl
+++ b/chart/hello/templates/_helpers.tpl
@@ -14,3 +14,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a ClusterIP service name based on the fullname with "-cip" suffix.
+We truncate at 59 (63 chars - ("-cip".length)) because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullnamecip" -}}
+{{- $chartName := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $chartName | trunc 59 | trimSuffix "-" | printf "%s-cip" -}}
+{{- end -}}

--- a/chart/hello/templates/ingress.yaml
+++ b/chart/hello/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "fullname" . -}}
-{{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+{{- $servicePort := .Values.service_cluster_ip.externalPort }}
+{{- $serviceName := include "fullnamecip" . }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
@@ -10,10 +10,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  # annotations:
+  #   {{- range $key, $value := .Values.ingress.annotations }}
+  #     {{ $key }}: {{ $value | quote }}
+  #   {{- end }}
 spec:
   rules:
     {{- range $host := .Values.ingress.hosts }}
@@ -24,9 +24,13 @@ spec:
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-    {{- end -}}
-  {{- if .Values.ingress.tls }}
+    {{- end }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- range $tls := .Values.ingress.tls }}
+  - secretName: {{ $tls.secretName }}
+    hosts:
+    {{- range $tlsHost := $tls.hosts }}
+    - {{ $tlsHost }}
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/chart/hello/templates/service-cip.yaml
+++ b/chart/hello/templates/service-cip.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullnamecip" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service_cluster_ip.type }}
+  ports:
+    - port: {{ .Values.service_cluster_ip.externalPort }}
+      targetPort: {{ .Values.service_cluster_ip.internalPort }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/chart/hello/values.yaml
+++ b/chart/hello/values.yaml
@@ -14,19 +14,26 @@ service:
   type: NodePort
   externalPort: 80
   internalPort: 8080
+service_cluster_ip:
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
 ingress:
+  # used in the deploy script:
+  detectClusterIngressEnabled: true
+  # may be automatically set to true when detect cluster ingress
   enabled: false
   # Used to create an Ingress record.
   hosts:
-    - chart-example.local
+    - hello-app.cluster-ingress-subdomain
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:
     # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  - secretName: cluster-ingress-secret
+    hosts:
+    - hello-app.cluster-ingress-subdomain
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION

For clusters that have disabled NodePort but that do have cluster ingress enabled, 
to add a Kubernetes Ingress resource that can be optionally installed depending on cluster ingress detection.

Related to the similar previous change in the hello-containers repo:
- Add ingress definition
   https://github.com/open-toolchain/hello-containers/pull/6

