### PR TITLE
Update Chart.yaml

### DIFF
--- a/chart/hello/Chart.yaml
+++ b/chart/hello/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for a Kubernetes app
 name: hello
-version: 1.0
+version: "1.0"


### PR DESCRIPTION
helm3 linter fails with simply 1.0 with this error: `[ERROR] Chart.yaml: version should be of type string but it's of type float64`.

The current script expects to have helm2 for the lint call and then it installs helm3. If helm3 is the default helm version, then the linter call fails with the error above.